### PR TITLE
feat(copy): implement copy link functionality

### DIFF
--- a/apps/web/app/components/FileCard/FileCard.tsx
+++ b/apps/web/app/components/FileCard/FileCard.tsx
@@ -45,6 +45,11 @@ const FileCardMenuContent: React.FC<FileCardMenuContentProps> = ({
     })
   }
 
+  const handleCopy = () => {
+    const url = `${window.location.origin}/api/files/${file.path}/thumbnail`;
+    navigator.clipboard.writeText(url);
+  };
+
   return (
     <Menu.Content>
       <Stack
@@ -82,7 +87,9 @@ const FileCardMenuContent: React.FC<FileCardMenuContentProps> = ({
       >
         Set as folder cover
       </Menu.Item>
-      <Menu.Item before={<Link className="text-secondary" />}>
+      <Menu.Item
+        onClick={handleCopy}
+        before={<Link className="text-secondary" />}>
         Copy link
       </Menu.Item>
       <Menu.Item before={<Download className="text-secondary" />}>
@@ -125,7 +132,7 @@ const FileCard: React.FC<FileCardProps> = ({
   selectItem,
   ...props
 }) => {
-  const [isDropdownOpen, setDropdownOpen] = useState(false)
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
 
   return (
     <Menu.Root openOnContextMenu onOpenChange={setDropdownOpen}>


### PR DESCRIPTION
### **Description:**

- ✨ **Added** a feature to copy a dynamic URL link to the clipboard.
- 🌐 The URL is generated by combining the **base URL** with the specific file path for easy access.
- 📋 The URL is automatically copied to the clipboard when triggered by a user action (e.g., button click).
- 🚀 This functionality enhances the user experience by enabling easy sharing of links.

---

### **Changes:**

- 🔧 **Added** a `handleCopy` function that dynamically retrieves the file URL.
- 📝 Used `navigator.clipboard.writeText` to copy the URL to the user's clipboard.
- 🔍 Improved the code to dynamically fetch the **hostname** using `window.location.origin` to ensure compatibility across environments (development, production, etc.).

---

### **Why:** 

- ❌ This feature was not available in the app previously, and it improves usability by allowing users to easily copy links for sharing or future access.

---

### **Testing:**

- ✅ **Manually tested** the copy link functionality by clicking the copy button.
- ✔️ Verified that the correct URL is copied to the clipboard.
- 🌍 Ensured that the app works properly in different environments.

---

### **Related Issues:** 

- 🚫 No related issues.
